### PR TITLE
refactor: Modify backup task to use the 'copy' module instead of 'shell'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,7 +108,7 @@
     - name: Gather facts for ansible_date_time
       setup:
         filter:
-          - 'ansible_date_time'
+          - ansible_date_time
       when: postfix_backup_multiple | bool
 
     - name: Backup configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,14 +105,20 @@
 - name: Apply changes
   when: __postfix_has_config_changed | d("") is search("True")
   block:
+    - name: Gather facts for ansible_date_time
+      setup:
+        filter:
+          - 'ansible_date_time'
+      when: postfix_backup_multiple | bool
+
     - name: Backup configuration
-      shell: >-
-        set -euo pipefail;
-        cp /etc/postfix/main.cf
-        /etc/postfix/main.cf.{{ postfix_backup_multiple |
-        ternary("$(date -Iseconds)", "backup") }}
+      copy:
+        remote_src: true
+        src: /etc/postfix/main.cf
+        dest: /etc/postfix/main.cf.{{ postfix_backup_multiple |
+          ternary(ansible_date_time.iso8601, "backup") }}
+        mode: '0644'
       when: postfix_backup or postfix_backup_multiple
-      changed_when: true
 
     - name: Ensure Last modified header is absent
       lineinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,7 +117,7 @@
         src: /etc/postfix/main.cf
         dest: /etc/postfix/main.cf.{{ postfix_backup_multiple |
           ternary(ansible_date_time.iso8601, "backup") }}
-        mode: '0644'
+        mode: "0644"
       when: postfix_backup or postfix_backup_multiple
 
     - name: Ensure Last modified header is absent


### PR DESCRIPTION
Enhancement: Use the `copy` module instead of copying with `shell: cp`.

Result: This helps to enforce a desired state model and reduces ambiguity on success/failure.