### PR TITLE
Fix yamllint errors

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,9 +6,7 @@ galaxy_info:
   license: GPL-3.0+
   min_ansible_version: 2.2
   platforms:
-  - name: Fedora
-    versions: [ 24, 25 ]
-  - name: EL
-    versions: [ 6, 7 ]
-
-
+    - name: Fedora
+      versions: [ 24, 25 ]
+    - name: EL
+      versions: [ 6, 7 ]


### PR DESCRIPTION
Fixes indentation and remove empty lines at the end of the file 
in role's metadata:
--> Executing Yamllint on files found in postfix/...
    meta/main.yml
      9:3       error    wrong indentation: expected 4 but found 2  (indentation)
      14:1      error    too many blank lines (2 > 0)  (empty-lines)