### PR TITLE
Check each postfix_conf before applying

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,4 +29,4 @@
   command: "postconf -e \"{{ item.key }}={{ item.value }}\""
   ignore_errors: true
   notify: check restart postfix
-  with_dict: "{{ postfix_conf }}"
+  loop: "{{ postfix_conf | dict2items }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,8 +25,16 @@
     insertbefore: BOF
     line: "# This file is managed by Ansible"
 
+- name: Check Postfix config option
+  shell: "postconf -h \"{{ item.key }}\" | grep \"^{{ item.value | regex_escape }}$\""
+  ignore_errors: true
+  changed_when: false
+  loop: "{{ postfix_conf | dict2items }}"
+  register: postconf_check
+
 - name: Configure Postfix
-  command: "postconf -e \"{{ item.key }}={{ item.value }}\""
+  command: "postconf -e \"{{ item.item.key }}={{ item.item.value }}\""
   ignore_errors: true
   notify: check restart postfix
-  loop: "{{ postfix_conf | dict2items }}"
+  when: item.rc != 0
+  loop: "{{ postconf_check.results }}"


### PR DESCRIPTION
Before this change, every addition to `postfix_conf` would register as a change in Ansible, even on successive runs. This will only apply a change if the value is not what the vars are set to during the playbook run.

Tested against both test plays with Ansible 2.7.10 and 2.8.0.