### PR TITLE
dont end with changed state when desired value is already in place

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,6 @@ postfix_backup: false
 # Whether to do multiple backups with timestamp (if true) or
 # single backup (if false and postfix_backup == true)
 postfix_backup_multiple: true
+
+# variable to hold the postconf key which needs update
+postfix_conf_outstanding: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,28 +5,49 @@
 - name: Enable Postfix
   service: name=postfix state=started enabled=yes
 
-- name: Backup configuration
-  shell: cp /etc/postfix/main.cf /etc/postfix/main.cf.{{ postfix_backup_multiple | ternary("`date -Iseconds`", "backup") }}
-  when: postfix_backup or postfix_backup_multiple
-
-- name: Add header 1 to configuration file
-  lineinfile:
-    dest: /etc/postfix/main.cf
-    regexp: '# Last modified:'
-    state: present
-    insertbefore: BOF
-    line: "# Last modified: {{ ansible_date_time.date }}\n"
-
-- name: Add header 2 to configuration file
-  lineinfile:
-    dest: /etc/postfix/main.cf
-    regexp: 'managed by [aA]nsible'
-    state: present
-    insertbefore: BOF
-    line: "# This file is managed by Ansible"
-
-- name: Configure Postfix
-  command: "postconf -e \"{{ item.key }}={{ item.value }}\""
+- name: Check Postfix 
+  shell: "postconf -h \"{{ item.key }}\" | grep -w \"{{ item.value }}\""
   ignore_errors: true
-  notify: check restart postfix
   with_dict: "{{ postfix_conf }}"
+  register: checkpostfix
+  changed_when: False
+
+
+- name: Set outstanding config options
+  set_fact:
+    postfix_conf_outstanding: "{{ postfix_conf_outstanding + [item.item.key] }}" 
+  loop: "{{checkpostfix.results}}"
+  when: item.rc != 0
+
+- block:
+  - name: Backup configuration
+    shell: cp /etc/postfix/main.cf /etc/postfix/main.cf.{{ postfix_backup_multiple | ternary("`date -Iseconds`", "backup") }}
+    when: postfix_backup or postfix_backup_multiple
+  
+  - name: Add header 1 to configuration file
+    lineinfile:
+      dest: /etc/postfix/main.cf
+      regexp: '# Last modified:'
+      state: present
+      insertbefore: BOF
+      line: "# Last modified: {{ ansible_date_time.date }}\n"
+  
+  - name: Add header 2 to configuration file
+    lineinfile:
+      dest: /etc/postfix/main.cf
+      regexp: 'managed by [aA]nsible'
+      state: present
+      insertbefore: BOF
+      line: "# This file is managed by Ansible"
+
+  - name: debug
+    debug:
+      var: postfix_conf_outstanding
+  
+  - name: Configure Postfix
+    command: "postconf -e \"{{ item.key }}={{ item.value }}\""
+    ignore_errors: true
+    notify: check restart postfix
+    with_dict: "{{ postfix_conf }}"
+    when: item.key in postfix_conf_outstanding
+  when: (postfix_conf_outstanding|length >0)


### PR DESCRIPTION
I added a bunch of tasks to check (postconf -h) whether the desired value is in place or not. If the desired value is active no backup and no `postconf -e` will be executed and the tasks end with OK instead of CHANGED