### PR TITLE
make role idempotent - no date in config file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,15 +13,13 @@
     ternary("$(date -Iseconds)", "backup") }}
   when: postfix_backup or postfix_backup_multiple
 
-- name: Add header 1 to configuration file
+- name: Ensure Last modified header is absent
   lineinfile:
     dest: /etc/postfix/main.cf
     regexp: '# Last modified:'
-    state: present
-    insertbefore: BOF
-    line: "# Last modified: {{ ansible_date_time.date }}\n"
+    state: absent
 
-- name: Add header 2 to configuration file
+- name: Ensure Ansible Managed header in configuration file
   lineinfile:
     dest: /etc/postfix/main.cf
     regexp: 'managed by [aA]nsible'


### PR DESCRIPTION
https://github.com/linux-system-roles/postfix/issues/21
It is a bad practice to put the date in the header of the config
file.  This change will not put the date in the header, and will
ensure the "Last Modified" header is absent.