### PR TITLE
Add postfix_reset functionality that resets configuration to Red Hat defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ thus keeping multiple backup copies.  The default is `true`.  NOTE: This setting
 overrides `postfix_backup`, so you must set this to `false` if you want to use
 `postfix_backup`.
 
+### postfix_reset
+
+```
+postfix_reset: false
+```
+
+This is a boolean which determines if the role resets the postfix configuration
+to default values. You can use this with `postfix_conf` to reset settings to
+default values and apply your desired configuration on top of default settings.
+
 ## Limitations
 
 There is no way to remove configuration parameters.  If you know all of the

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,4 @@ postfix_backup: false
 # Whether to do multiple backups with timestamp (if true) or
 # single backup (if false and postfix_backup == true)
 postfix_backup_multiple: true
+postfix_reset: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -140,3 +140,6 @@
       command: postconf -e {{ item.key | quote }}={{ item.value | quote }}
       notify: check restart postfix
       with_dict: "{{ postfix_conf }}"
+      when: __postfix_has_config_changed | d("") is search(
+        "True itemstr " + item.key
+        )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,84 @@
     state: started
     enabled: yes
 
+- name: Add default values for changed settings to postfix_conf
+  when: postfix_reset | bool
+  block:
+    - name: Get settings that are different from default
+      shell: |
+        set -euo pipefail
+
+        settings_to_apply=__postconf_settings_to_apply.txt
+        current_settings=__postconf_current.txt
+        default_settings=__postconf_defaults.txt
+        postconf > $current_settings
+        postconf -d > $default_settings
+
+        # This is the list of settings that differ on RHEL and Fedora from what
+        # `postconf -d` displays by default
+        declare -A red_hat_defaults
+        red_hat_defaults["alias_maps"]="hash:/etc/aliases"
+        red_hat_defaults["compatibility_level"]="2"
+        red_hat_defaults["debugger_command"]='PATH=/bin:/usr/bin:/usr/local/bin:/usr/X11R6/bin ddd $daemon_directory/$process_name $process_id \& sleep 5'
+        red_hat_defaults["inet_interfaces"]="localhost"
+        red_hat_defaults["mailq_path"]="/usr/bin/mailq.postfix"
+        red_hat_defaults["manpage_directory"]="/usr/share/man"
+        red_hat_defaults["mynetworks"]="127.0.0.1/32 [::1]/128"
+        red_hat_defaults["newaliases_path"]="/usr/bin/newaliases.postfix"
+        red_hat_defaults["readme_directory"]="/usr/share/doc/postfix/README_FILES"
+        red_hat_defaults["sample_directory"]="/usr/share/doc/postfix/samples"
+        red_hat_defaults["sendmail_path"]="/usr/sbin/sendmail.postfix"
+        red_hat_defaults["smtp_tls_CAfile"]="/etc/pki/tls/certs/ca-bundle.crt"
+        red_hat_defaults["smtp_tls_CApath"]="/etc/pki/tls/certs"
+        red_hat_defaults["smtp_tls_security_level"]="may"
+        red_hat_defaults["smtpd_tls_cert_file"]="/etc/pki/tls/certs/postfix.pem"
+        red_hat_defaults["smtpd_tls_key_file"]="/etc/pki/tls/private/postfix.key"
+        red_hat_defaults["smtpd_tls_security_level"]="may"
+
+        # Settings that must keep the value
+        # smtpd_expansion filter is difficult to compare
+        # process_id is unique for each system
+        settings_to_ignore="smtpd_expansion_filter process_id"
+
+        # In $default_settings, substitute values for settings that differ from
+        # the upstream default
+        for K in "${!red_hat_defaults[@]}"; do
+          sed -i "s|^$K.*|$K = ${red_hat_defaults[$K]}|g" $default_settings
+        done
+
+        if [ -f "$settings_to_apply" ]; then
+          rm $settings_to_apply
+        fi
+
+        # Compare $default_settings with $current_settings and append settings
+        # that differ to $settings_to_apply
+        while read line; do
+          if ! grep -Fxq "$line" $current_settings; then
+            echo $line >> $settings_to_apply
+          fi
+        done < $default_settings
+
+        # Remove inapplicable settings from the $settings_to_apply list
+        for i in $settings_to_ignore; do
+          sed -i "/^$i/d" $settings_to_apply
+        done
+
+        cat $settings_to_apply
+        rm $current_settings $default_settings $settings_to_apply --force
+      register: __postfix_reset_settings
+      changed_when: false
+
+    - name: Create a dictionary of settings that needs reset with default values
+      set_fact:
+        __postfix_reset_settings_dict: "{{ dict(__postfix_reset_settings.stdout_lines | map('regex_search', '^([^=\\s]*)\\s*=\\s*(.*)', '\\1', '\\2') | list ) }}"
+
+    - name: Merge postfix_conf and __postfix_reset_settings_dict
+      set_fact:
+        postfix_conf: "{{ postfix_conf | default({}) | combine ({ item.key : item.value }) }}"
+      with_dict:
+        - "{{ __postfix_reset_settings_dict }}"
+        - "{{ postfix_conf }}"
+
 - name: Get current config
   command: postconf
   register: __postfix_register_config


### PR DESCRIPTION
The implementation is pretty ugly because postfix default settings in the upstream are different from Red Hat (in Fedora, RHEL and CentOS) default settings.
i.e. while upstream default value of `inte_interfaces` is all:
```
# postconf -d inet_interfaces
inet_interfaces = all
```
RHEL default value after the clear provisioning of the machine and `dnf install postfix` is different:
```
# postconf inet_interfaces
inet_interfaces = localhost
```
I guess this happens in the spec file here:
https://src.fedoraproject.org/rpms/postfix/blob/rawhide/f/postfix.spec#_359

I have opened a PR about this for postfix:
https://bugzilla.redhat.com/show_bug.cgi?id=2055024

For the time being, we must work with it as is. So I've written a bash script that gets the default settings and then substitute values for the settings that are different in Red Hat postfix in this default settings list.

Another way is to remove `/etc/postfix/main.cf` and do `dnf reinstall postfix`, not idempotent. My solution is idempotent but dirty.

This PR fixes the following BZ: 
https://bugzilla.redhat.com/show_bug.cgi?id=2055024