### PR TITLE
support gather_facts: false; support setup-snapshot.yml (#71)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Ensure ansible_facts required by role
+  include_tasks: set_facts.yml
+
 # Distribution defaults are different from the postfix defaults, hence need to
 # reinstall the package
 - name: Remove the {{ __postfix_packages }} package to restore config

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: BSD-3-Clause
+---
+- name: Ensure ansible_facts used by role are present
+  setup:
+    gather_subset: min
+  when:
+    - __postfix_required_facts is defined
+    - not ansible_facts.keys() | list |
+      intersect(__postfix_required_facts) == __postfix_required_facts

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,12 @@
+- hosts: all
+  tasks:
+    - name: Set facts used by role
+      include_role:
+        name: linux-system-roles.postfix
+        tasks_from: set_facts.yml
+        public: true
+
+    - name: Install test packages
+      package:
+        name: "{{ __postfix_packages }}"
+        state: present

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,5 +1,5 @@
 - name: Ensure that the rule runs with default parameters
   hosts: all
-
+  gather_facts: false
   roles:
     - linux-system-roles.postfix

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-only
 # List of default rpm packages to install.
 __postfix_packages: ['postfix']
+
+# currently unused
+# __postfix_required_facts


### PR DESCRIPTION
Some users use `gather_facts: false` in their playbooks.  This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages.  tests/setup-snapshot.yml can be used by a CI system
to do this.
