### PR TITLE
[citest skip] tox-lsr 2.13.0; check-meta-versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
   - push
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.11.0"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.0"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default
@@ -41,6 +41,6 @@ jobs:
           36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck" ;;
           38) toxenvs="${toxenvs},coveralls,ansible-lint,ansible-plugin-scan,collection,ansible-test" ;;
           39) toxenvs="${toxenvs},coveralls,ansible-managed-var-comment" ;;
-          310) toxenvs="${toxenvs},coveralls,custom" ;;
+          310) toxenvs="${toxenvs},coveralls,custom,check-meta-versions" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox


### PR DESCRIPTION
Update to tox-lsr 2.13.0 - this adds check-meta-versions to py310

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
