### PR TITLE
Use the firewall role and the selinux role from the postfix role

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,23 @@
 
 This role can install, configure and start Postfix MTA.
 
+## Requirements
+
+The role requires the `firewall` role and the `selinux` role from the
+`fedora.linux_system_roles` collection, if `postfix_manage_firewall`
+and `postfix_manage_selinux` is set to true, respectively.
+(Please see also [`postfix_manage_firewall`](#postfix_manage_firewall)
+ and [`postfix_manage_selinux`](#postfix_manage_selinux))
+
+If the `postfix` is a role from the `fedora.linux_system_roles`
+collection or from the Fedora RPM package, the requirement is already
+satisfied.
+
+Otherwise, please run the following command line to install the collection.
+```
+ansible-galaxy collection install -r meta/collection-requirements.yml
+```
+
 # Role Variables
 
 ### postfix_conf

--- a/README.md
+++ b/README.md
@@ -72,6 +72,33 @@ thus keeping multiple backup copies.  The default is `true`.  NOTE: This setting
 overrides `postfix_backup`, so you must set this to `false` if you want to use
 `postfix_backup`.
 
+### postfix_manage_firewall
+
+Boolean flag allowing to configure firewall using the firewall role.
+Manage the smtp related ports, 25/tcp, 465/tcp, and 587/tcp.
+If the variable is set to `false`, the `postfix role` does not manage the
+firewall.
+Default to `false`.
+
+NOTE: `postfix_manage_firewall` is limited to *adding* ports.
+It cannot be used for *removing* ports.
+If you want to remove ports, you will need to use the firewall system
+role directly.
+
+NOTE: the firewall management is not supported on RHEL 6.
+
+### postfix_manage_selinux
+
+Boolean flag allowing to configure selinux using the selinux role.
+Assign `smtp_port_t` to the smtp related ports.
+If the variable is set to false, the `postfix role` does not manage the
+selinux
+
+NOTE: `postfix_manage_selinux` is limited to *adding* policy.
+It cannot be used for *removing* policy.
+If you want to remove policy, you will need to use the selinux system
+role directly.
+
 ## Limitations
 
 There is no way to remove configuration parameters.  If you know all of the

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,11 @@ postfix_backup: false
 # Whether to do multiple backups with timestamp (if true) or
 # single backup (if false and postfix_backup == true)
 postfix_backup_multiple: true
+
+# If true, manage the smtp related ports, 25/tcp, 465/tcp, and
+# 587/tcp using the firewall role.
+postfix_manage_firewall: false
+
+# If true, manage the smtp related ports, 25/tcp, 465/tcp, and
+# 587/tcp using the selinux role.
+postfix_manage_selinux: false

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+collections:
+  - fedora.linux_system_roles

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure the postfix ports status with the firewall role
+  include_role:
+    name: fedora.linux_system_roles.firewall
+  vars:
+    firewall:
+      - {'service': 'smtp', 'state': 'enabled' }
+      - {'service': 'smtps', 'state': 'enabled' }
+      - {'service': 'smtp-submission', 'state': 'enabled' }
+  when:
+    - postfix_manage_firewall | bool
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution_version'] is version('7', '>=')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,12 @@
         selectattr('stdout', 'search', ' /etc/postfix/.*[.]cf($|\n)') |
         list | length > 0
 
+- name: Configure firewall
+  include_tasks: firewall.yml
+
+- name: Configure selinux
+  include_tasks: selinux.yml
+
 - name: Install Postfix
   package:
     name: "{{ __postfix_packages }}"

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+---
+- block:
+    - block:
+        - name: Get the smtp related tcp service ports
+          shell: |-
+            set -euo pipefail
+            firewall-cmd --info-service="{{ item }}" | \
+              egrep " +ports: +" | sed -e "s/ *ports: //"
+          register: __ports
+          changed_when: false
+          loop:
+            - "smtp"
+            - "smtps"
+            - "smtp-submission"
+
+        - name: Initialize _postfix_selinux
+          set_fact:
+            _postfix_selinux: []
+
+        - name: Add the smtp related service ports to _postfix_selinux
+          set_fact:
+            _postfix_selinux: "{{ _postfix_selinux +
+                [{'ports': _pair[0], 'proto': _pair[1], 'setype': 'smtp_port_t',
+                  'state': 'present', 'local': 'true'}] }}"
+          vars:
+            _pair: "{{ item.stdout.split('/') | list }}"
+          when:
+            - _pair | length > 0
+          loop: "{{ __ports.results }}"
+
+      when:
+        - postfix_manage_firewall | bool
+        - ansible_facts['os_family'] == 'RedHat'
+        - ansible_facts['distribution_version'] is version('7', '>=')
+
+    - name: "Set hardcoded ports to _postfix_selinux for
+             no firewall or rhel-6 or not redhat"
+      set_fact:
+        _postfix_selinux:
+          - {'ports': 25, 'proto': 'tcp', 'setype': 'smtp_port_t',
+             'state': 'present', 'local': 'true'}
+          - {'ports': 465, 'proto': 'tcp', 'setype': 'smtp_port_t',
+             'state': 'present', 'local': 'true'}
+          - {'ports': 587, 'proto': 'tcp', 'setype': 'smtp_port_t',
+             'state': 'present', 'local': 'true'}
+      when:
+        - (not postfix_manage_firewall | bool) or
+          (ansible_facts['os_family'] != 'RedHat') or
+          (ansible_facts['distribution_version'] is version('7', '<'))
+
+    - name: Ensure the service and the ports status with the selinux role
+      include_role:
+        name: fedora.linux_system_roles.selinux
+      vars:
+        selinux_ports: "{{ _postfix_selinux }}"
+  when:
+    - postfix_manage_selinux | bool

--- a/tests/check_firewall_selinux.yml
+++ b/tests/check_firewall_selinux.yml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+---
+# Assume firewalld and selinux are not manually configured.
+- block:
+    - name: Get the firewall services
+      shell: |-
+        set -euo pipefail
+        firewall-cmd --list-services
+      register: __services
+      changed_when: false
+
+    - name: Assert the expected services are configured
+      assert:
+        that: "'{{ item }}' in {{ __service_list }}"
+      vars:
+        __service_list: "{{ __services.stdout.split(' ') }}"
+      loop:
+        - "smtp"
+        - "smtps"
+        - "smtp-submission"
+  when:
+    - postfix_manage_firewall | bool
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution_version'] is version('7', '>=')
+
+- block:
+    - name: Ensure smtp ports are retrieved
+      assert:
+        that: "{{ _postfix_selinux | length > 0 }}"
+
+    - name: Check associated selinux
+      shell: |-
+        set -euo pipefail
+        semanage port --list -C | grep "smtp_port_t" | \
+          grep "{{ item['proto'] }}" | grep "{{ item['ports'] }}"
+      changed_when: false
+      loop: "{{ _postfix_selinux }}"
+  when:
+    - postfix_manage_selinux | bool

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,5 +1,15 @@
 - name: Ensure that the rule runs with default parameters
   hosts: all
   gather_facts: false
-  roles:
-    - linux-system-roles.postfix
+
+  tasks:
+    - name: Run the postfix role
+      include_role:
+        name: linux-system-roles.postfix
+        public: true
+      vars:
+        postfix_manage_firewall: true
+        postfix_manage_selinux: true
+
+    - name: Check firewall and selinux status
+      include_tasks: check_firewall_selinux.yml

--- a/tests/tests_previous_replaced.yml
+++ b/tests/tests_previous_replaced.yml
@@ -5,20 +5,32 @@
     - name: Run the role with previous=replaced only
       include_role:
         name: linux-system-roles.postfix
+        public: true
       vars:
+        postfix_manage_firewall: true
+        postfix_manage_selinux: false
         postfix_conf:
           previous: replaced
+
+    - name: Check firewall and selinux status
+      include_tasks: check_firewall_selinux.yml
 
     - name: Run the role to configure relay_domains and relayhost
       include_role:
         name: linux-system-roles.postfix
+        public: true
       vars:
+        postfix_manage_firewall: true
+        postfix_manage_selinux: true
         postfix_conf:
           relay_domains: London
           relayhost: example.com
 
     - name: Flush handlers
       meta: flush_handlers
+
+    - name: Check firewall and selinux status
+      include_tasks: check_firewall_selinux.yml
 
     - name: Reset all settings and configure relay_domains
       include_role:

--- a/tests/tests_set_banner.yml
+++ b/tests/tests_set_banner.yml
@@ -4,10 +4,15 @@
   vars:
     postfix_conf:
       smtpd_banner: test
-  roles:
-    - linux-system-roles.postfix
+    postfix_manage_firewall: false
+    postfix_manage_selinux: true
 
   tasks:
+    - name: Run the role with test smtpd_banner
+      include_role:
+        name: linux-system-roles.postfix
+        public: true
+
     - name: Get smtpd banner
       command: postconf smtpd_banner
       register: smtpd_banner
@@ -18,3 +23,6 @@
         that: "{{
           smtpd_banner.stdout_lines[0] ==
           'smtpd_banner = ' + postfix_conf.smtpd_banner }}"
+
+    - name: Check firewall and selinux status
+      include_tasks: check_firewall_selinux.yml

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,5 +2,7 @@
 # List of default rpm packages to install.
 __postfix_packages: ['postfix']
 
-# currently unused
-# __postfix_required_facts
+# ansible_facts required by the role
+__postfix_required_facts:
+  - distribution_version
+  - os_family


### PR DESCRIPTION
- Introduce postfix_manage_firewall to use the firewall role to manage the smtp services. Default to false - means the firewall role is not used.

- Introduce postfix_manage_selinux to use the selinux role to manage the ports in the smtp services. Assign smtp_port_t to the smtp service ports. Default to false - means the selinux role is not used.

- Add the test check task tasks/check_firewall_selinux.yml for verify the ports status.

- Add meta/collection-requirements.yml.