### PR TITLE
Add check for non-inclusive language

### DIFF
--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,18 @@
+# yamllint disable rule:line-length
+name: Check for non-inclusive language
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+jobs:
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml"
+          # Cause the check to fail on any broke rules
+          fail-on-error: true

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ clean postfix installation.
 
 **WARNING**: If you specify `previous: replaced`, the role reinstalls the postfix
 package and replaces the existing `/etc/postfix/main.cf` and
-`/etc/postix/master.cf` files. Ensure to back up those files to preserve your
-settings.
+`/etc/postfix/master.cf` files. <!--- wokeignore:rule=master -->
+Ensure to back up those files to preserve your settings.
 
 If you specify only `previous: replaced` under the `postfix_conf` dictionary,
 the role re-installs the `postfix` package and enables the `postfix` service


### PR DESCRIPTION
Add a check for usage of terms and language that is considered
non-inclusive. We are using the woke tool for this with a wordlist
that can be found at
https://github.com/linux-system-roles/tox-lsr/blob/main/src/tox_lsr/config_files/woke.yml

README.md - cleanup non-inclusive words.