### PR TITLE
ansible-lint 6.x fixes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,21 @@
 ---
+profile: production
 skip_list:
-  - '403'
-  - fqcn-builtins  # Use FQCN for builtin actions.
+  - fqcn-builtins
+exclude_paths:
+  - tests/roles/
+  - .github/
+  - examples/roles/
+kinds:
+  - yaml: "**/meta/collection-requirements.yml"
+  - yaml: "**/tests/collection-requirements.yml"
+  - playbook: "**/tests/tests_*.yml"
+  - playbook: "**/tests/setup-snapshot.yml"
+  - tasks: "**/tests/*.yml"
+  - playbook: "**/tests/playbooks/*.yml"
+  - tasks: "**/tests/tasks/*.yml"
+  - tasks: "**/tests/tasks/*/*.yml"
+  - vars: "**/tests/vars/*.yml"
+  - playbook: "**/examples/*.yml"
+mock_roles:
+  - linux-system-roles.postfix

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: MIT
+---
 collections:
   - fedora.linux_system_roles

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,3 +1,4 @@
+---
 galaxy_info:
   author: Jaroslav Škarvada <jskarvad@redhat.com>
   description: Configure Postfix

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -5,9 +5,9 @@
     name: fedora.linux_system_roles.firewall
   vars:
     firewall:
-      - {'service': 'smtp', 'state': 'enabled' }
-      - {'service': 'smtps', 'state': 'enabled' }
-      - {'service': 'smtp-submission', 'state': 'enabled' }
+      - {'service': 'smtp', 'state': 'enabled'}
+      - {'service': 'smtps', 'state': 'enabled'}
+      - {'service': 'smtp-submission', 'state': 'enabled'}
   when:
     - postfix_manage_firewall | bool
     - ansible_facts['os_family'] == 'RedHat'

--- a/tests/check_firewall_selinux.yml
+++ b/tests/check_firewall_selinux.yml
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: MIT
 ---
 # Assume firewalld and selinux are not manually configured.
-- block:
+- name: Manage firewall
+  when:
+    - postfix_manage_firewall | bool
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution_version'] is version('7', '>=')
+  block:
     - name: Get the firewall services
       shell: |-
         set -euo pipefail
@@ -18,12 +23,10 @@
         - "smtp"
         - "smtps"
         - "smtp-submission"
-  when:
-    - postfix_manage_firewall | bool
-    - ansible_facts['os_family'] == 'RedHat'
-    - ansible_facts['distribution_version'] is version('7', '>=')
 
-- block:
+- name: Manage SELinux
+  when: postfix_manage_selinux | bool
+  block:
     - name: Ensure smtp ports are retrieved
       assert:
         that: "{{ _postfix_selinux | length > 0 }}"
@@ -35,5 +38,3 @@
           grep "{{ item['proto'] }}" | grep "{{ item['ports'] }}"
       changed_when: false
       loop: "{{ _postfix_selinux }}"
-  when:
-    - postfix_manage_selinux | bool

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Setup snapshot
+  hosts: all
   tasks:
     - name: Set facts used by role
       include_role:

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,7 +1,7 @@
+---
 - name: Ensure that the rule runs with default parameters
   hosts: all
   gather_facts: false
-
   tasks:
     - name: Run the postfix role
       include_role:

--- a/tests/tests_set_banner.yml
+++ b/tests/tests_set_banner.yml
@@ -1,3 +1,4 @@
+---
 - name: Set smtpd banner
   hosts: all
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-only
+---
 # List of default rpm packages to install.
 __postfix_packages: ['postfix']
 


### PR DESCRIPTION
All tasks must be named
Task names must begin with uppercase letter
Fix jinja code spacing
block/rescue/always should come after name, when, etc.
Other issues
