### PR TITLE
fix issues with jinja, ansible-lint

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,13 +50,13 @@
   command: postconf
   register: __postfix_register_config
   changed_when: false
-  when: postfix_conf | dict2items | rejectattr( 'key', 'match', '^previous$' )
+  when: postfix_conf | dict2items | rejectattr('key', 'match', '^previous$')
     | list | items2dict | d({}) | length > 0
 
 - name: Check given config against current config
   changed_when: false
   when:
-    - postfix_conf | dict2items | rejectattr( 'key', 'match', '^previous$' )
+    - postfix_conf | dict2items | rejectattr('key', 'match', '^previous$')
       | list | items2dict | d({}) | length > 0
     - __postfix_register_config is defined
     - __postfix_register_config.stdout_lines is defined
@@ -115,4 +115,4 @@
       when:
         - item.key not in ['previous']
         - __postfix_has_config_changed
-          | d("") is search("True itemstr " + item.key)
+          | d("") is search("True itemstr " ~ item.key)

--- a/tests/check_firewall_selinux.yml
+++ b/tests/check_firewall_selinux.yml
@@ -16,20 +16,20 @@
 
     - name: Assert the expected services are configured
       assert:
-        that: "'{{ item }}' in {{ __service_list }}"
+        that: item in __service_list
       vars:
         __service_list: "{{ __services.stdout.split(' ') }}"
       loop:
-        - "smtp"
-        - "smtps"
-        - "smtp-submission"
+        - smtp
+        - smtps
+        - smtp-submission
 
 - name: Manage SELinux
   when: postfix_manage_selinux | bool
   block:
     - name: Ensure smtp ports are retrieved
       assert:
-        that: "{{ _postfix_selinux | length > 0 }}"
+        that: _postfix_selinux | length > 0
 
     - name: Check associated selinux
       shell: |-

--- a/tests/tests_set_banner.yml
+++ b/tests/tests_set_banner.yml
@@ -21,9 +21,8 @@
 
     - name: Assert smtpd banner is valid
       assert:
-        that: "{{
-          smtpd_banner.stdout_lines[0] ==
-          'smtpd_banner = ' + postfix_conf.smtpd_banner }}"
+        that: smtpd_banner.stdout_lines[0] ==
+          'smtpd_banner = ' ~ postfix_conf.smtpd_banner
 
     - name: Check firewall and selinux status
       include_tasks: check_firewall_selinux.yml


### PR DESCRIPTION
Code in `when`, `that`, and similar conditionals is already interpreted
as Jinja constructs, so remove the {{ }}
Fix some spacing issues with Jinja functions
Use `~` instead of `+` for Jinja string concatenation
