### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/get_ansible_managed.j2
+++ b/templates/get_ansible_managed.j2
@@ -1,1 +1,2 @@
 {{ ansible_managed | comment }}
+{{ "system_role:postfix" | comment(prefix="", postfix="") }}


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:postfix
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.