### PR TITLE
ansible-lint - use changed_when for conditional tasks

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,7 @@
 - name: Check postfix
   command: postfix check
   when: postfix_check
+  changed_when: false
 
 - name: Restart postfix
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,6 +82,7 @@
         /etc/postfix/main.cf.{{ postfix_backup_multiple |
         ternary("$(date -Iseconds)", "backup") }}
       when: postfix_backup or postfix_backup_multiple
+      changed_when: true
 
     - name: Ensure Last modified header is absent
       lineinfile:
@@ -113,6 +114,10 @@
         - Restart postfix
       with_dict: "{{ postfix_conf }}"
       when:
+        - item.key not in ['previous']
+        - __postfix_has_config_changed
+          | d("") is search("True itemstr " ~ item.key)
+      changed_when:
         - item.key not in ['previous']
         - __postfix_has_config_changed
           | d("") is search("True itemstr " ~ item.key)


### PR DESCRIPTION
ansible-lint now requires the use of changed_when even for
conditional tasks

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
