### PR TITLE
feat: Added postfix_files feature as a simple means to add extra files/maps to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ postfix_conf:
   relayhost: example.com
 ```
 
+### postfix_files
+
+```yaml
+postfix_files:
+  - name: sasl_passwd
+    content: example.com user:password
+    postmap: true
+  - name: sender_canonical_maps
+    content: /.+/  info@example.com
+```
+
+This is a list of files that will be placed in /etc/postfix and that can be converted into Postfix Lookup Tables if needed.
+
+It's meant as a simple mechanism to configure things such as SASL credentials and other small snippets.
+
 ### postfix_check
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,15 @@
 #
 postfix_conf: {}
 
+# Additional config maps/files, e.g.:
+# postfix_files:
+#   - name: 'sasl_passwd'
+#     content: 'smtp.example.com user@example.com:myFirstPassword
+#     postmap: true
+#   - name: 'sender_canonical_maps'
+#     content: '/.+/    user@example.com'
+postfix_files: []
+
 # Whether to run 'postfix check' before it's started
 postfix_check: true
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,6 +102,33 @@
       {%   endif %}
       {% endfor %}
 
+- name: Configure additional files
+  copy:
+    content: "{{ file['content'] }}"
+    dest: /etc/postfix/{{ file['name'] }}
+    owner: root
+    group: root
+    mode: '0640'
+  loop: "{{ postfix_files }}"
+  register: __postfix_postmap_files
+  no_log: true
+  loop_control:
+    loop_var: file
+  notify:
+    - Check postfix
+    - Restart postfix
+
+- name: Postmap files
+  command: postmap {{ result["dest"] | quote }}
+  when:
+    - result["changed"]
+    - result["file"]["postmap"] | d(false)
+  no_log: true
+  changed_when: true
+  loop: "{{ __postfix_postmap_files['results'] }}"
+  loop_control:
+    loop_var: result
+
 - name: Apply changes
   when: __postfix_has_config_changed | d("") is search("True")
   block:

--- a/tests/tests_set_file.yml
+++ b/tests/tests_set_file.yml
@@ -1,0 +1,33 @@
+---
+- name: Create a postmapped file
+  hosts: all
+
+  vars:
+    postfix_files:
+      - name: test
+        content: test
+        postmap: true
+
+  tasks:
+    - name: Run the role with test postmap file
+      include_role:
+        name: linux-system-roles.postfix
+        public: true
+
+    - name: Check if postmap file exists
+      stat:
+        path: /etc/postfix/test.db
+      register: test_file
+      changed_when: false
+
+    - name: Assert file is present
+      assert:
+        that: test_file.stat.exists
+
+    - name: Clean up test files
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/postfix/test
+        - /etc/postfix/test.db


### PR DESCRIPTION
Enhancement: Added a means to configure extra files for Postfix

Reason: Some config options require to pick up additional information from a file (e.g. with SASL credentials etc). This PR adds 'postfix_files', a simple means of creating these files and integrating them in the Postfix configuration. 

Result: 

Issue Tracker Tickets (Jira or BZ if any):
