### PR TITLE
feat: Make the role work on Debian based systems

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,6 +111,8 @@
         cp /etc/postfix/main.cf
         /etc/postfix/main.cf.{{ postfix_backup_multiple |
         ternary("$(date -Iseconds)", "backup") }}
+      args:
+        executable: /bin/bash
       when: postfix_backup or postfix_backup_multiple
       changed_when: true
 


### PR DESCRIPTION
Enhancement: Make role work on Debian

Reason: I have a few systems that run Debian and I wanted to configure Postfix on them in the same manner as I do RHEL based systems.

Result: Role now works on Debian (note that SELinux and Firewalld are not supported/tested)

Issue Tracker Tickets (Jira or BZ if any):
