### PR TITLE
fix: Reflect smtp-submission service rename in EL 10 and Fedora 40+

### DIFF
--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -13,13 +13,10 @@
           shell: |-
             set -euo pipefail
             firewall-cmd --info-service="{{ item }}" | \
-              egrep " +ports: +" | sed -e "s/ *ports: //"
+              grep -E " +ports: +" | sed -e "s/ *ports: //"
           register: __ports
           changed_when: false
-          loop:
-            - "smtp"
-            - "smtps"
-            - "smtp-submission"
+          loop: "{{ __postfix_smtp_services }}"
 
         - name: Initialize _postfix_selinux
           set_fact:

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -17,3 +17,14 @@
     - name: Set flag to indicate system is ostree
       set_fact:
         __postfix_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
+- name: Set platform/version specific variables
+  include_vars: "{{ __postfix_vars_file }}"
+  loop:
+    - "{{ ansible_os_family }}.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution }}_{{ ansible_distribution_version }}.yml"
+  vars:
+    __postfix_vars_file: "{{ role_path }}/vars/{{ item }}"
+  when: __postfix_vars_file is file

--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-only
+---
+__postfix_smtp_services:
+  - smtp
+  - smtps
+  - smtp-submission

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-only
+---
+__postfix_smtp_services:
+  - smtp
+  - smtps
+  - smtp-submission

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-only
+---
+__postfix_smtp_services:
+  - smtp
+  - smtps
+  - smtp-submission

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-only
+---
+__postfix_smtp_services:
+  - smtp
+  - smtps
+  - submission

--- a/vars/Fedora_39.yml
+++ b/vars/Fedora_39.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-only
+---
+__postfix_smtp_services:
+  - smtp
+  - smtps
+  - smtp-submission

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-only
+---
+__postfix_smtp_services:
+  - smtp
+  - smtps
+  - submission

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-only
+---
+__postfix_smtp_services:
+  - smtp
+  - smtps
+  - smtp-submission

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-only
+---
+__postfix_smtp_services:
+  - smtp
+  - smtps
+  - smtp-submission

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-only
+---
+__postfix_smtp_services:
+  - smtp
+  - smtps
+  - smtp-submission

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: GPL-3.0-only
 ---
 # List of default rpm packages to install.
-__postfix_packages: ['postfix']
+__postfix_packages:
+  - postfix
+
+__postfix_smtp_services:
+  - smtp
+  - smtps
+  - smtp-submission
 
 # ansible_facts required by the role
 __postfix_required_facts:


### PR DESCRIPTION
Enhancement: Rename `smtp-submission` to `submission` on EL 10 and Fedora 40+

Reason: Since Fedora 40, `smtp-submission` service has been renamed to submission
https://github.com/firewalld/firewalld/commit/d6a9561260c0ff81fb2e0a105768749c5c819561
