### PR TITLE
fix: add support for EL10

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,6 @@
 galaxy_info:
   author: Jaroslav Škarvada <jskarvad@redhat.com>
   description: Configure Postfix
-  galaxy_tags: [system, beta]
   company: Red Hat, Inc.
   license: GPL-3.0+
   min_ansible_version: "2.9"
@@ -16,3 +15,12 @@ galaxy_info:
         - "7"
         - "8"
         - "9"
+  galaxy_tags:
+    - beta
+    - el6
+    - el7
+    - el8
+    - el9
+    - el10
+    - fedora
+    - system

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -12,8 +12,20 @@
         - name: Get the smtp related tcp service ports
           shell: |-
             set -euo pipefail
-            firewall-cmd --info-service="{{ item }}" | \
-              grep -E " +ports: +" | sed -e "s/ *ports: //"
+            ports="$(firewall-cmd --info-service="{{ item }}" | \
+              grep -E " +ports: +" | sed -e "s/ *ports: //")" || :
+            if [ -z "$ports" ]; then
+              include="$(firewall-cmd --info-service="{{ item }}" | \
+                awk '/^ +includes:/ {print $2}')" || :
+              if [ -n "$include" ]; then
+                ports="$(firewall-cmd --info-service="$include" | \
+                  grep -E " +ports: +" | sed -e "s/ *ports: //")"
+              fi
+            fi
+            if [ -z "$ports" ]; then
+              exit 1
+            fi
+            echo "$ports"
           register: __ports
           changed_when: false
           loop: "{{ __postfix_smtp_services }}"

--- a/vars/CentOS_10.yml
+++ b/vars/CentOS_10.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-only
+---
+__postfix_smtp_services:
+  - smtp
+  - smtps
+  - smtp-submission

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-only
+---
+__postfix_smtp_services:
+  - smtp
+  - smtps
+  - smtp-submission


### PR DESCRIPTION
According to the Ansible team, support for listing platforms in
role `meta/main.yml` files is being removed.
Instead, they recommend using `galaxy_tags`

https://github.com/ansible/ansible/blob/stable-2.17/changelogs/CHANGELOG-v2.17.rst
"Remove the galaxy_info field platforms from the role templates"
https://github.com/ansible/ansible/issues/82453

Many roles already have tags such as "rhel", "redhat", "centos", and "fedora".
I propose that we ensure all of the system roles have these tags.
Some of our roles support Suse, Debian, Ubuntu, and others.
We should add tags for those e.g. the ssh role already has tags for "debian" and "ubuntu".

In addition - for each version listed under `platforms.EL` - add a tag like `elN`.

Q: Why not use a delimiter between the platform and the version e.g. `el-10`?

This is not allowed by ansible-lint:

```
meta-no-tags: Tags must contain lowercase letters and digits only., invalid: 'el-10'
meta/main.yml:1
```

So we cannot use uppercase letters either.

Q: Why not use our own meta/main.yml field?

No other fields are allowed by ansible-lint:

```
syntax-check[specific]: 'myfield' is not a valid attribute for a RoleMetadata
```

Q: Why not use some other field?

There are no other applicable or suitable fields.

Q: What happens when we want to support versions like `N.M`?

Use the word "dot" instead of "." e.g. `el10dot3`.
Similarly - use "dash" instead of "-".

We do not need tags such as `fedoraall`.
The `fedora` tag implies that the role works on all supported versions of fedora.
Otherwise, use tags such as `fedora40` if the role only supports specific versions.

In addition - for roles that have different variable files for EL9, create
the corresponding EL10 files.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
