### PR TITLE
fix: support different postmap map types for EL10 and other platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ It cannot be used for *removing* policy.
 If you want to remove policy, you will need to use the selinux system
 role directly.
 
+### postfix_map_type
+
+String - this is the map type to use with `postfix_files` for the `postmap`
+command.  It is not recommended to use this - instead, let the role use the
+platform default.
+
 ## Limitations
 
 There is no way to remove separate configuration parameters.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ postfix_conf: {}
 #     postmap: true
 #   - name: 'sender_canonical_maps'
 #     content: '/.+/    user@example.com'
+# See postfix_map_type to use a non-default map type
 postfix_files: []
 
 # Whether to run 'postfix check' before it's started
@@ -32,3 +33,8 @@ postfix_manage_firewall: false
 # If true, manage the smtp related ports, 25/tcp, 465/tcp, and
 # 587/tcp using the selinux role.
 postfix_manage_selinux: false
+
+# Map type to use.  See postconf -m for a list of
+# map types.  It is recommended not to set this and
+# to use the platform default.
+postfix_map_type: "{{ __postfix_default_map_type }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -119,7 +119,7 @@
     - Restart postfix
 
 - name: Postmap files
-  command: postmap {{ result["dest"] | quote }}
+  command: postmap {{ __map_type ~ result["dest"] | quote }}
   when:
     - result["changed"]
     - result["file"]["postmap"] | d(false)
@@ -128,6 +128,10 @@
   loop: "{{ __postfix_postmap_files['results'] }}"
   loop_control:
     loop_var: result
+  vars:
+    __map_type: "{{ postfix_map_type ~ ':'
+      if postfix_map_type | length > 0
+      else '' }}"
 
 - name: Apply changes
   when: __postfix_has_config_changed | d("") is search("True")

--- a/tests/tests_set_file.yml
+++ b/tests/tests_set_file.yml
@@ -5,7 +5,7 @@
   vars:
     postfix_files:
       - name: test
-        content: test
+        content: test_key test_value
         postmap: true
 
   tasks:
@@ -14,9 +14,15 @@
         name: linux-system-roles.postfix
         public: true
 
+    - name: Set postmap result file name
+      set_fact:
+        __postmap_file: /etc/postfix/test.{{
+          postfix_map_type if postfix_map_type | length > 0
+          else 'db' }}
+
     - name: Check if postmap file exists
       stat:
-        path: /etc/postfix/test.db
+        path: "{{ __postmap_file }}"
       register: test_file
       changed_when: false
 
@@ -30,4 +36,4 @@
         state: absent
       loop:
         - /etc/postfix/test
-        - /etc/postfix/test.db
+        - "{{ __postmap_file }}"

--- a/vars/CentOS_10.yml
+++ b/vars/CentOS_10.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-only
 ---
+__postfix_default_map_type: "lmdb"
+
 __postfix_smtp_services:
   - smtp
   - smtps
-  - smtp-submission
+  - smtp-submissions

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 ---
+__postfix_default_map_type: "lmdb"
+
 __postfix_smtp_services:
   - smtp
   - smtps

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,6 +9,11 @@ __postfix_smtp_services:
   - smtps
   - smtp-submission
 
+# map type for postmap 'type:/path'
+# e.g. hash:/etc/postmap/mymap
+# default is "" - empty - use postmap default
+__postfix_default_map_type: ""
+
 # ansible_facts required by the role
 __postfix_required_facts:
   - distribution_version


### PR DESCRIPTION
Cause: EL10 changed the default map type, and now requires the map
type to be explicitly specified.

Consequence: The role will give an error when using postfix_files
on EL 10.

Fix: Create a new variable postfix_map_type that the user can use
to specify a different map type.  Make sure the default value of
this is correct on el10 and earlier platforms.

Result: User can specify postfix_files on EL10 and earlier
platforms.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
