### PR TITLE
ci: Add workflow for ci_test bad, use remote fmf plan

### DIFF
--- a/.github/workflows/tft_citest_bad.yml
+++ b/.github/workflows/tft_citest_bad.yml
@@ -29,11 +29,15 @@ jobs:
             | jq -r "[.workflow_runs[] | select( .display_title == \"$PR_TITLE\") | \
             select(.status == \"pending\" or .status == \"queued\" or .status == \"in_progress\") | .id][0]")
           # if pending run don't exist, take the last run with failure state
-          if [ "$PENDING_RUN" = "null" ]; then
-            RUN_ID=$(gh api "repos/$REPO/actions/workflows/tft.yml/runs?event=issue_comment" \
-              | jq -r "[.workflow_runs[] | select( .display_title == \"$PR_TITLE\" ) | select( .conclusion == \"failure\" ) | .id][0]")
-            echo "Re-running workflow $RUN_ID"
-            gh api --method POST repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs
-          else
+          if [ "$PENDING_RUN" != "null" ]; then
             echo "The workflow $PENDING_RUN is still running, wait for it to finish to re-run"
+            exit 1
           fi
+          RUN_ID=$(gh api "repos/$REPO/actions/workflows/tft.yml/runs?event=issue_comment" \
+            | jq -r "[.workflow_runs[] | select( .display_title == \"$PR_TITLE\" ) | select( .conclusion == \"failure\" ) | .id][0]")
+          if [ "$RUN_ID" = "null" ]; then
+            echo "Failed workflow not found, exitting"
+            exit 1
+          fi
+          echo "Re-running workflow $RUN_ID"
+          gh api --method POST repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs


### PR DESCRIPTION
* Remove plan from role dir, it's too complicated and long to run tests from tmt
* Use plan from linux-system-roles/tft-tests
* Move getting datetime to testing-farm job where it's used
* Add a workflow for running [citest_bad]
* Bump sclorg/testing-farm-as-github-action to v3
* Move concurrency group to first job
* Dump GitHub context

Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
