### PR TITLE
feat: support postfix_default_database_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,25 @@ It cannot be used for *removing* policy.
 If you want to remove policy, you will need to use the selinux system
 role directly.
 
+## Variables Exported by the Role
+
+### postfix_default_database_type
+
+This is a string which specifies the default database type used by postfix,
+which is obtained by using `postconf -h default_database_type`.  This can be
+used to set configuration which depends on the type. **NOTE** this is *not*
+supported with Ansible 2.9.
+
+```yaml
+- name: Manage postfix
+  hosts: all
+  vars:
+    postfix_conf:
+      relay_domains: "{{ postfix_default_database_type }}:/etc/postfix/relay_domains"
+  roles:
+    - linux-system-roles.postfix
+```
+
 ## Limitations
 
 There is no way to remove separate configuration parameters.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,15 @@
     use: "{{ (__postfix_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
+- name: Get default database type from postconf
+  command: postconf -h default_database_type
+  changed_when: false
+  register: __postfix_register_dbtype
+
+- name: Set postfix_default_database_type
+  set_fact:
+    postfix_default_database_type: "{{ __postfix_register_dbtype.stdout | trim }}"
+
 - name: Enable Postfix
   service:
     name: postfix

--- a/tests/tests_set_file.yml
+++ b/tests/tests_set_file.yml
@@ -7,6 +7,9 @@
       - name: test
         content: test
         postmap: true
+    __test_file_suffix: "{{ '.lmdb'
+      if postfix_default_database_type == 'lmdb'
+      else '.db' }}"
 
   tasks:
     - name: Run the role with test postmap file
@@ -19,20 +22,36 @@
         path: /etc/postfix/test{{ __test_file_suffix }}
       register: test_file
       changed_when: false
-      vars:
-        __test_file_suffix: "{{ '.lmdb' if ansible_facts['os_family'] == 'RedHat'
-          and ansible_facts['distribution'] != 'Fedora'
-          and ansible_facts['distribution_major_version'] is version('10', '>=')
-          else '.db' }}"
 
     - name: Assert file is present
       assert:
         that: test_file.stat.exists
 
+    - name: Check relay_domains
+      when: ansible_version["major"] > 2 or ansible_version["minor"] > 9
+      block:
+        # cannot use postfix_default_database_type with postfix_conf
+        # in ansible 2.9
+        - name: Run the role to test postfix_default_database_type
+          include_role:
+            name: linux-system-roles.postfix
+            public: true
+          vars:
+            postfix_conf:
+              relay_domains: "{{
+                postfix_default_database_type }}:/etc/postfix/relay_domains"
+
+        - name: Get relay_domains
+          command: postconf -h relay_domains
+          changed_when: false
+          register: __test_relay_domains
+
+        - name: Check relay_domains
+          assert:
+            that: __test_relay_domains.stdout | trim ==
+              postfix_default_database_type ~ ":/etc/postfix/relay_domains"
+
     - name: Clean up test files
       file:
-        path: "{{ item }}"
+        path: /etc/postfix/test{{ __test_file_suffix }}
         state: absent
-      loop:
-        - /etc/postfix/test
-        - /etc/postfix/test.db


### PR DESCRIPTION
Feature: The role will determine the default database type used by postfix
and will export that value as the variable `postfix_default_database_type`

Reason: Users need to be able to set configuration parameter values
based on the database type.

Result: Users can set configuration parameter values based on the
default database type.

NOTE: Using postfix_default_database_type in a configuration parameter
value is not supported on Ansible 2.9 due to the way 2.9 does variable
evaluation.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>