### PR TITLE
refactor: support ansible 2.19

### DIFF
--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -9,8 +9,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __ansible_managed in content
       - __fingerprint in content
   vars:
     content: "{{ (__file_content | d(__content)).content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/tests_previous_replaced.yml
+++ b/tests/tests_previous_replaced.yml
@@ -29,7 +29,7 @@
     - name: Flush handlers
       meta: flush_handlers
 
-    - name: Check firewall and selinux status
+    - name: Check firewall and selinux status again
       include_tasks: check_firewall_selinux.yml
 
     - name: Check header for ansible_managed, fingerprint
@@ -46,7 +46,7 @@
           previous: replaced
           relay_domains: Liverpool city
 
-    - name: Flush handlers
+    - name: Flush handlers again
       meta: flush_handlers
 
     - name: Print postfix settings that have explicit value set


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Refactor test suite to support Ansible 2.19 by updating header assertion variable names and disambiguating duplicate task names

Enhancements:
- Use __ansible_managed variable in header check assertions to match Ansible 2.19

Tests:
- Rename duplicate test task names for firewall and selinux check and flush handlers for clarity