### PR TITLE
docs(changelog): version 1.6.1 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -58,8 +58,9 @@ SOFTWARE.
   </style>
   <style type="text/css">code{white-space: pre;}</style>
   <style type="text/css">
+html { -webkit-text-size-adjust: 100%; }
 pre > code.sourceCode { white-space: pre; position: relative; }
-pre > code.sourceCode > span { line-height: 1.25; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
 .sourceCode { overflow: visible; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
@@ -70,7 +71,7 @@ div.sourceCode { overflow: auto; }
 }
 @media print {
 pre > code.sourceCode { white-space: pre-wrap; }
-pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
 }
 pre.numberSource code
   { counter-reset: source-line 0; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 Changelog
 =========
 
+[1.6.1] - 2025-07-09
+--------------------
+
+### Other Changes
+
+- ci: ansible-plugin-scan is disabled for now (#168)
+- ci: bump ansible-lint to v25; provide collection requirements for ansible-lint (#171)
+- ci: Check spelling with codespell (#172)
+- ci: Add test plan that runs CI tests and customize it for each role (#173)
+- ci: In test plans, prefix all relate variables with SR_ (#174)
+- ci: Fix bug with ARTIFACTS_URL after prefixing with SR_ (#175)
+- ci: several changes related to new qemu test, ansible-lint, python versions, ubuntu versions (#176)
+- ci: use tox-lsr 3.6.0; improve qemu test logging (#177)
+- ci: skip storage scsi, nvme tests in github qemu ci (#178)
+- ci: Bump sclorg/testing-farm-as-github-action from 3 to 4 (#179)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#180)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#181)
+- ci: Add support for bootc end-to-end validation tests (#182)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#183)
+- refactor: support ansible 2.19 (#184)
+
 [1.6.0] - 2024-12-04
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.6.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare release 1.6.1 by updating the changelog and README, refine CI workflows, fix CI environment variables, and add Ansible 2.19 support.

Bug Fixes:
- Fix ARTIFACTS_URL in CI test plans after prefixing related variables with SR_

Enhancements:
- Add Ansible 2.19 support

CI:
- Disable ansible-plugin-scan and upgrade ansible-lint to v25 with collection requirements
- Add Codespell spell checking to CI
- Enhance test plans with SR_-prefixed variables and bump tox-lsr across versions
- Improve QEMU tests by adding logging, renaming tests, skipping storage tests, and adding bootc end-to-end validation
- Bump testing-farm GitHub Action and add Fedora 42 with Python 3.13 testing

Documentation:
- Update CHANGELOG.md for version 1.6.1
- Adjust HTML/CSS in README for improved code block rendering and text-size scaling