### PR TITLE
fix: accept empty relayhost as unset

### DIFF
--- a/tests/tests_previous_replaced.yml
+++ b/tests/tests_previous_replaced.yml
@@ -59,4 +59,5 @@
         that:
           - __postfix_explicit_config.stdout is search(
             "relay_domains = Liverpool city")
-          - __postfix_explicit_config.stdout is not search("relayhost")
+          - (__postfix_explicit_config.stdout | regex_search('^relayhost\\s*=\\s*$', multiline=True)) or
+            __postfix_explicit_config.stdout is not search("relayhost")


### PR DESCRIPTION
Enhancement: updated test condition

Reason: On Sles, reinstalling Postfix sets `relayhost =` in `/etc/postfix/main.cf` rather than removing it entirely. This causes the test to fail, even though the parameter is effectively unset.

Result: updated test condition to accept both absence and empty value (relayhost =) as valid cases of an unset relayhost

Issue Tracker Tickets (Jira or BZ if any): na