### PR TITLE
docs(changelog): version 1.6.3 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+[1.6.3] - 2025-07-24
+--------------------
+
+### Other Changes
+
+- test: accept empty relayhost as unset (#189)
+
 [1.6.2] - 2025-07-15
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.6.3

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare for version 1.6.3 release by updating the CHANGELOG and README with the latest change

Documentation:
- Add version 1.6.3 entry to CHANGELOG documenting the acceptance of an empty relayhost as unset
- Update README.html to reflect the new 1.6.3 release