### PR TITLE
test: tag tests::reboot for tests_disable_ipv6.yml

### DIFF
--- a/tests/tests_disable_ipv6.yml
+++ b/tests/tests_disable_ipv6.yml
@@ -1,6 +1,8 @@
 ---
 - name: Ensure that the rule runs with IPv6 disabled
   hosts: all
+  tags:
+    - tests::reboot
   gather_facts: false
   tasks:
     - name: Disable IPv6


### PR DESCRIPTION
This test must be tagged tests::reboot because it reboots
the managed node.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Tests:
- Add tests::reboot tag to the disable IPv6 playbook to correctly mark it as a reboot test