### PR TITLE
docs(changelog): version 1.6.5 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 Changelog
 =========
 
+[1.6.5] - 2025-11-17
+--------------------
+
+### Bug Fixes
+
+- fix: cannot use community-general version 12 - no py27 and py36 support (#207)
+
+### Other Changes
+
+- ci: bump actions/checkout from 4 to 5 (#193)
+- ci: rollout several recent changes to CI testing (#195)
+- ci: support openSUSE Leap in qemu/kvm test matrix (#196)
+- ci: use the new epel feature to enable EPEL for testing farm (#197)
+- ci: use tox-lsr 3.12.0 for osbuild_config.yml feature (#199)
+- ci: use JSON format for __bootc_validation (#200)
+- ci: bump actions/github-script from 7 to 8 (#201)
+- ci: bump actions/upload-artifact from 4 to 5 (#202)
+- ci: use versioned upload-artifact instead of master; bump codeql-action to v4; bump upload-artifact to v5 (#203)
+- ci: bump tox-lsr to 3.13.0 (#204)
+- ci: bump tox-lsr to 3.14.0 - this moves standard-inventory-qcow2 to tox-lsr (#205)
+
 [1.6.4] - 2025-08-01
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.6.5

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Add changelog entry for version 1.6.5 documenting a bug fix and multiple CI updates

Bug Fixes:
- Fix inability to use community-general version 12 without py27 and py36 support

CI:
- Update CI workflows and dependencies: bump actions/checkout, upload-artifact, github-script, codeql-action; upgrade tox-lsr; enable openSUSE Leap and new EPEL testing features; apply recent CI testing rollouts