### PR TITLE
feat: new variable `postfix_secure_logging` defaulting to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ It cannot be used for *removing* policy.
 If you want to remove policy, you will need to use the selinux system
 role directly.
 
+### postfix_secure_logging
+
+If `true`, suppress potentially sensitive output from tasks that handle
+credentials, secrets, and other sensitive data by setting `no_log: true` on
+those tasks. This prevents passwords, API tokens, private keys, and similar
+sensitive information from appearing in Ansible logs and console output.
+
+If you need to debug issues with credential handling or secret management, you
+can temporarily set `postfix_secure_logging: false` to see the full output from
+these tasks. However, be aware that this may expose sensitive information in
+logs, so it should only be used in development or troubleshooting scenarios.
+
+Default: `true`
+
 ## Variables Exported by the Role
 
 ### postfix_default_database_type

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,4 @@ postfix_manage_firewall: false
 # If true, manage the smtp related ports, 25/tcp, 465/tcp, and
 # 587/tcp using the selinux role.
 postfix_manage_selinux: false
+postfix_secure_logging: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -143,7 +143,7 @@
     mode: '0640'
   loop: "{{ postfix_files }}"
   register: __postfix_postmap_files
-  no_log: true
+  no_log: "{{ postfix_secure_logging }}"
   loop_control:
     loop_var: file
   notify:
@@ -155,7 +155,7 @@
   when:
     - result["changed"]
     - result["file"]["postmap"] | d(false)
-  no_log: true
+  no_log: "{{ postfix_secure_logging }}"
   changed_when: true
   loop: "{{ __postfix_postmap_files['results'] }}"
   loop_control:


### PR DESCRIPTION
Feature: Introduce the `postfix_secure_logging` variable that defaults to `true`.

Reason: Currently, all sensitive tasks use hard-coded no_log: true, which makes debugging difficult. Users cannot see credential-related output even when troubleshooting authentication or secret management issues.

Result:
  - Tasks handling credentials, secrets, and sensitive data now use no_log: "{{ postfix_secure_logging }}", allowing users to set postfix_secure_logging: false for debugging while maintaining secure defaults (true)
  - New variable postfix_secure_logging documented in README.md with guidance on when to disable it
  - Users can now debug credential and secret issues without modifying role code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a configurable secure logging toggle for sensitive Postfix role tasks, defaulting to secure behavior while allowing opt-out for debugging.

New Features:
- Add a postfix_secure_logging variable to control whether sensitive Postfix tasks suppress output via no_log.

Enhancements:
- Update sensitive Postfix tasks to use the postfix_secure_logging variable instead of hard-coded no_log settings for more flexible debugging control.

Documentation:
- Document the postfix_secure_logging variable in the README, including its purpose, default value, and guidance on when to disable it.