### PR TITLE
docs: fix broken quoting in postfix_files defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ postfix_files:
     content: example.com user:password
     postmap: true
   - name: sender_canonical_maps
-    content: /.+/  info@example.com
+    content: /.+/  user@example.com
 ```
 
 This is a list of files that will be placed in /etc/postfix and that can be converted into Postfix Lookup Tables if needed.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,11 +8,11 @@ postfix_conf: {}
 
 # Additional config maps/files, e.g.:
 # postfix_files:
-#   - name: 'sasl_passwd'
-#     content: 'smtp.example.com user@example.com:myFirstPassword
+#   - name: sasl_passwd
+#     content: example.com user:password
 #     postmap: true
-#   - name: 'sender_canonical_maps'
-#     content: '/.+/    user@example.com'
+#   - name: sender_canonical_maps
+#     content: /.+/  user@example.com
 postfix_files: []
 
 # Whether to run 'postfix check' before it's started


### PR DESCRIPTION
The comment added to `defaults/main.yml` for `postfix_files` in 73b7c72 (Added postfix_files feature as a simple means to add extra files/maps to the postfix config, 2024-06-09) included unneeded quotes.  One of them was unclosed.  Rather than add the closing quote, drop them to match the example provided in `README.md`.

Adjust the address used in the content field of the `README.md` example to match what's used elsewhere in the examples.  The commented variable in defaults and the README now contain the same data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example configuration entries for `postfix_files` and optional Postfix maps
  * Refined formatting and placeholder examples in documented code snippets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->