### PR TITLE
ci: replace weekly_ci with periodic_ci, stagger schedules [citest_skip]

### DIFF
--- a/.github/workflows/periodic_ci.yml
+++ b/.github/workflows/periodic_ci.yml
@@ -1,12 +1,12 @@
 ---
 # yamllint disable rule:line-length
-name: Weekly CI trigger
+name: Periodic CI trigger
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   schedule:
-    - cron: 0 17 * * 6
+    - cron: 0 3 * * 0
 env:
-  BRANCH_NAME: weekly-ci
+  BRANCH_NAME: periodic-ci
   COMMIT_MESSAGE: "ci: This PR is to trigger periodic CI testing"
   BODY_MESSAGE: >-
     This PR is for the purpose of triggering periodic CI testing.
@@ -16,7 +16,9 @@ env:
 permissions:
   contents: read
 jobs:
-  weekly_ci:
+  periodic_ci:
+    # Set repository or organization variable PERIODIC_CI_ENABLED='true' to enable
+    if: vars.PERIODIC_CI_ENABLED == 'true'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
Rename the weekly CI trigger workflow to periodic_ci.  The name better
reflects that this is for recurring CI, not necessarily weekly.

Stagger the scheduled start times so that roles do not all compete for
the limited github action job capacity at once.  The first role starts
Saturday 02:00 UTC, and each subsequent role starts one hour later, with
an extra hour after ha_cluster, snapshot, and storage because those tests
typically take longer.

Periodic CI is disabled by default.  Set the repository or organization
variable `ENABLED` to `true` to enable it.  We don't currently use it.
We may enable it in the future.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
