### PR TITLE
ci: update status when action triggered by issue comment

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -24,6 +24,8 @@ env:
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   ansible_lint:
     if: |
@@ -77,23 +79,35 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
-      - name: Get PR head SHA
+      - name: Get PR head SHA and context
         if: github.event_name == 'issue_comment'
-        id: head_sha
+        id: head_sha_context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / ${{ github.job }} (${{ matrix.versions.ansible_lint }}, ${{ matrix.versions.ansible }}, ${{ matrix.versions.python }}) (pull_request)"
         run: |
           set -euxo pipefail
           head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
 
       - name: Install tox, tox-lsr
         run: |
@@ -115,3 +129,13 @@ jobs:
           LSR_ANSIBLE_LINT_ANSIBLE_DEP="ansible-core==${{ matrix.versions.ansible }}" \
           tox -x testenv:ansible-lint-collection.basepython="python${{ matrix.versions.python }}" \
           -e ansible-lint-collection
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -21,6 +21,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   ansible_managed_var_comment:
     if: |
@@ -66,23 +68,35 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
-      - name: Get PR head SHA
+      - name: Get PR head SHA and context
         if: github.event_name == 'issue_comment'
-        id: head_sha
+        id: head_sha_context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / ${{ github.job }} (pull_request)"
         run: |
           set -euxo pipefail
           head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
 
       - name: Install tox, tox-lsr
         run: |
@@ -93,3 +107,13 @@ jobs:
         run: |
           set -euxo pipefail
           TOXENV=ansible-managed-var-comment lsr_ci_runtox
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -24,6 +24,8 @@ env:
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   ansible_test:
     if: |
@@ -80,23 +82,35 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
-      - name: Get PR head SHA
+      - name: Get PR head SHA and context
         if: github.event_name == 'issue_comment'
-        id: head_sha
+        id: head_sha_context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / ${{ github.job }} (${{ matrix.versions.ansible }}, ${{ matrix.versions.python }}) (pull_request)"
         run: |
           set -euxo pipefail
           head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
 
       - name: Install tox, tox-lsr
         run: |
@@ -116,3 +130,13 @@ jobs:
           tox \
             -x testenv:ansible-test-${{ matrix.versions.ansible }}.basepython="python${{ matrix.versions.python }}" \
             -e ansible-test-${{ matrix.versions.ansible }}
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,6 +13,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   codespell:
     if: |
@@ -52,23 +54,45 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - name: Get PR head SHA
+      - name: Get PR head SHA and context
         if: github.event_name == 'issue_comment'
-        id: head_sha
+        id: head_sha_context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / Check for spelling errors (pull_request)"
         run: |
           set -euxo pipefail
           head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
 
       - name: Codespell
         uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -22,6 +22,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   markdownlint:
     if: |
@@ -66,23 +68,35 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
-      - name: Get PR head SHA
+      - name: Get PR head SHA and context
         if: github.event_name == 'issue_comment'
-        id: head_sha
+        id: head_sha_context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / ${{ github.job }} (pull_request)"
         run: |
           set -euxo pipefail
           head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
 
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
 
       # CHANGELOG.md is generated automatically from PR titles and descriptions
       # It might have issues but they are not critical
@@ -93,3 +107,13 @@ jobs:
             --ignore=CHANGELOG.md
             **/*.md
           config: .markdownlint.yaml
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -90,23 +90,25 @@ jobs:
       ANSIBLE_INJECT_FACT_VARS: "false"
 
     steps:
-      - name: Get PR head SHA
+      - name: Get PR head SHA and context
         if: github.event_name == 'issue_comment'
-        id: head_sha
+        id: head_sha_context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / scenario (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
         run: |
           set -euxo pipefail
           head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
 
       - name: Check if platform is supported
         id: check_platform
@@ -143,6 +145,16 @@ jobs:
           fi
 
           echo "supported=$supported" >> "$GITHUB_OUTPUT"
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment' && steps.check_platform.outputs.supported
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
 
       - name: Set up /dev/kvm
         if: steps.check_platform.outputs.supported
@@ -290,11 +302,22 @@ jobs:
           done
           "${cmdline[@]}"
 
-      - name: Set commit status as success with a description that platform is skipped
-        if: ${{ steps.check_platform.outputs.supported == '' }}
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment' && steps.check_platform.outputs.supported
         uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
         with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""
+
+      - name: Set commit status as success with a description that platform is skipped
+        if: ${{ github.event_name == 'issue_comment' && steps.check_platform.outputs.supported == '' }}
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
           status: success
-          context: "${{ github.workflow }} / scenario (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
+          context: ${{ steps.head_sha_context.outputs.context }}
           description: The role does not support this platform. Skipping.
           targetUrl: ""

--- a/.github/workflows/test_converting_readme.yml
+++ b/.github/workflows/test_converting_readme.yml
@@ -21,6 +21,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   test_converting_readme:
     if: |
@@ -61,6 +63,7 @@ jobs:
     permissions:
       pull-requests: read
       contents: write
+      statuses: write
     steps:
       - name: Update pip, git
         run: |
@@ -68,23 +71,35 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
-      - name: Get PR head SHA
+      - name: Get PR head SHA and context
         if: github.event_name == 'issue_comment'
-        id: head_sha
+        id: head_sha_context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / ${{ github.job }} (pull_request)"
         run: |
           set -euxo pipefail
           head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
 
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
 
       - name: Remove badges from README.md prior to converting to HTML
         run: sed -i '1,8 {/^\[\!.*actions\/workflows/d}' README.md
@@ -102,3 +117,13 @@ jobs:
         with:
           name: README.html
           path: README.html
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -13,6 +13,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   woke:
     if: |
@@ -52,23 +54,35 @@ jobs:
     name: Detect non-inclusive language
     runs-on: ubuntu-latest
     steps:
-      - name: Get PR head SHA
+      - name: Get PR head SHA and context
         if: github.event_name == 'issue_comment'
-        id: head_sha
+        id: head_sha_context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / Detect non-inclusive language (pull_request)"
         run: |
           set -euxo pipefail
           head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
 
       - name: Run lsr-woke-action
         # Originally, uses: get-woke/woke-action@v0
@@ -77,3 +91,13 @@ jobs:
           woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml --count-only-error-for-failure"
           # Cause the check to fail on any broke rules
           fail-on-error: true
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""


### PR DESCRIPTION
issue comment triggers do not automatically update check
status in the PR, so use separate steps to update them,
similar to how the tft.yml workflow works.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commit status reporting for checks triggered by pull request comments.
  * Checks now show a pending status when they start and a final status when they complete.
  * Statuses are associated with the correct pull request commit across linting, testing, documentation, and integration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->